### PR TITLE
Add mechanisms for OAUTHBEARER and XOAUTH2

### DIFF
--- a/lib/Mail/IMAPClient.pm
+++ b/lib/Mail/IMAPClient.pm
@@ -3285,6 +3285,24 @@ sub authenticate {
             Authen::NTLM::ntlm($code);
         };
     }
+    elsif ( $scheme eq 'OAUTHBEARER' ) {
+        $response ||= sub {
+            my ( $code, $client ) = @_;
+            my $email = $client->User;
+            my $access_token = $client->Password; # OAuth2 token
+            my $auth_string = "n,a=$email,\001auth=Bearer $access_token\001\001";
+            encode_base64($auth_string, '');
+        };
+    }
+    elsif ( $scheme eq 'XOAUTH2' ) {
+        $response ||= sub {
+            my ( $code, $client ) = @_;
+            my $email = $client->User;
+            my $access_token = $client->Password; # OAuth2 token
+            my $auth_string = "user=$email\001auth=Bearer $access_token\001\001";
+            encode_base64($auth_string, '');
+        };
+    }
 
     my $resp = $response->( $code, $self );
     unless ( defined($resp) ) {

--- a/lib/Mail/IMAPClient.pod
+++ b/lib/Mail/IMAPClient.pod
@@ -107,6 +107,16 @@ is used as 'authcid'.  Otherwise, L</User> is used as 'authcid'.
 NTLM authentication requires the L<Authen::NTLM> module.  See also
 L</Domain>.
 
+=item OAUTHBEARER
+
+OAUTHBEARER authentication requires passing an OAuth2 access token
+in place of a password.
+
+=item XOAUTH2
+
+XOAUTH2 authentication requires passing an OAuth2 access token in
+place of a password.
+
 =back
 
 =head2 Errors


### PR DESCRIPTION
OAUTHBEARER and XOAUTH2 are two types for mechanisms that can be used for OAuth2.0 based authentication.

OAUTHBEARER is described in RFC5801 [1] and RFC7628 [2]. XOAUTH2 is Google's own method, described in their docs [3]

[1]: https://datatracker.ietf.org/doc/html/rfc5801
[2]: https://datatracker.ietf.org/doc/html/rfc7628
[3]: https://developers.google.com/gmail/imap/xoauth2-protocol#initial_client_response